### PR TITLE
Run kibana service as kibana4 user by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Kibana4 only works with recent versions of Elasticsearch (1.4.4 and later). I re
 
 * Downloads and extracts the kibana4 archive
 * Optionally create a user to use for the service
-* Creates an initrd file as one is not yet provided by the archive
+* Creates an init.d file as one is not yet provided by the archive
 * Modifies configuration file if needed.
 * Java installation is not managed by this module.
 
@@ -118,7 +118,7 @@ Only used if `package_provider` is 'archive'.
 
 [*manage_user*]
 
-Should the user that will run the Kibana service be created and managed by
+Should the user and group that will run the Kibana service be created and managed by
 Puppet? Defaults to 'false'.
 
 [*kibana4_user*]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,9 +12,9 @@ class kibana4::params {
   $service_enable              = true
   $service_name                = 'kibana4'
   $manage_user                 = false
-  $kibana4_group               = 'root'
+  $kibana4_group               = 'kibana4'
   $kibana4_gid                 = undef
-  $kibana4_user                = 'root'
+  $kibana4_user                = 'kibana4'
   $kibana4_uid                 = undef
   $install_dir                 = '/opt'
   $symlink                     = true

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -19,7 +19,7 @@ describe 'kibana4' do
     it { should_not contain_file('/opt/kibana').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('false').with_enable('false') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana\-4.0.0\-linux\-x64\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec root:root \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
   end
 
   context 'installs via archive and no symlink and service ensure and no user' do
@@ -36,7 +36,7 @@ describe 'kibana4' do
     it { should_not contain_file('/opt/kibana').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('true').with_enable('false') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana\-4.0.0\-linux\-x64\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec root:root \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
   end
 
   context 'installs via archive and no symlink and service ensure/enable and no user' do
@@ -53,7 +53,7 @@ describe 'kibana4' do
     it { should_not contain_file('/opt/kibana').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('true').with_enable('true') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana\-4.0.0\-linux\-x64\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec root:root \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
   end
 
   context 'installs via archive and symlink and no user' do
@@ -70,7 +70,7 @@ describe 'kibana4' do
     it { should contain_file('/opt/kibana4').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('false').with_enable('false') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana4\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec root:root \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
   end
 
   context 'installs via archive and symlink and service ensure and no user' do
@@ -87,7 +87,7 @@ describe 'kibana4' do
     it { should contain_file('/opt/kibana4').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('true').with_enable('false') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana4\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec root:root \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
   end
 
   context 'installs via archive and symlink and service ensure/enable and no user' do
@@ -104,7 +104,7 @@ describe 'kibana4' do
     it { should contain_file('/opt/kibana4').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('true').with_enable('true') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana4\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec root:root \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
   end
 
 
@@ -117,9 +117,9 @@ describe 'kibana4' do
         :symlink          => false,
         :package_ensure   => '4.0.0-linux-x64',
         :manage_user      => true,
-        :kibana4_user     => 'kibana4',
+        :kibana4_user     => 'kib4',
         :kibana4_uid      => '200',
-        :kibana4_group    => 'kibana4',
+        :kibana4_group    => 'kib4',
         :kibana4_gid      => '200',
         :service_enable   => false,
         :service_ensure   => false,
@@ -129,7 +129,7 @@ describe 'kibana4' do
     it { should_not contain_file('/opt/kibana').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('false').with_enable('false') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana\-4.0.0\-linux\-x64\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kib4:kib4 \/ sh -c "/) }
   end
 
   context 'installs via archive and no symlink and service ensure and user' do
@@ -139,9 +139,9 @@ describe 'kibana4' do
         :symlink          => false,
         :package_ensure   => '4.0.0-linux-x64',
         :manage_user      => true,
-        :kibana4_user     => 'kibana4',
+        :kibana4_user     => 'kib4',
         :kibana4_uid      => '200',
-        :kibana4_group    => 'kibana4',
+        :kibana4_group    => 'kib4',
         :kibana4_gid      => '200',
         :service_ensure   => true,
         :service_enable   => false,
@@ -151,7 +151,7 @@ describe 'kibana4' do
     it { should_not contain_file('/opt/kibana').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('true').with_enable('false') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana\-4.0.0\-linux\-x64\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kib4:kib4 \/ sh -c "/) }
   end
 
   context 'installs via archive and no symlink and service ensure/enable and no user' do
@@ -163,9 +163,9 @@ describe 'kibana4' do
         :service_ensure         => true,
         :service_enable         => true,
         :manage_user    => true,
-        :kibana4_user   => 'kibana4',
+        :kibana4_user   => 'kib4',
         :kibana4_uid    => '200',
-        :kibana4_group  => 'kibana4',
+        :kibana4_group  => 'kib4',
         :kibana4_gid    => '200',
       }
     end
@@ -173,7 +173,7 @@ describe 'kibana4' do
     it { should_not contain_file('/opt/kibana').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('true').with_enable('true') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana\-4.0.0\-linux\-x64\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kib4:kib4 \/ sh -c "/) }
   end
 
   context 'installs via archive and symlink and user' do
@@ -183,9 +183,9 @@ describe 'kibana4' do
         :symlink        => true,
         :package_ensure        => '4.0.0-linux-x64',
         :manage_user    => true,
-        :kibana4_user   => 'kibana4',
+        :kibana4_user   => 'kib4',
         :kibana4_uid    => '200',
-        :kibana4_group  => 'kibana4',
+        :kibana4_group  => 'kib4',
         :kibana4_gid    => '200',
         :service_ensure         => false,
         :service_enable         => false,
@@ -195,7 +195,7 @@ describe 'kibana4' do
     it { should contain_file('/opt/kibana4').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('false').with_enable('false') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana4\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kib4:kib4 \/ sh -c "/) }
   end
 
   context 'installs via archive and symlink and service ensure and user' do
@@ -206,9 +206,9 @@ describe 'kibana4' do
         :package_ensure   => '4.0.0-linux-x64',
         :service_ensure   => true,
         :manage_user      => true,
-        :kibana4_user     => 'kibana4',
+        :kibana4_user     => 'kib4',
         :kibana4_uid      => '200',
-        :kibana4_group    => 'kibana4',
+        :kibana4_group    => 'kib4',
         :kibana4_gid      => '200',
         :service_enable   => false,
       }
@@ -217,7 +217,7 @@ describe 'kibana4' do
     it { should contain_file('/opt/kibana4').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('true').with_enable('false') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana4\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kib4:kib4 \/ sh -c "/) }
   end
 
   context 'installs via archive and symlink and service ensure/enable and user' do
@@ -229,9 +229,9 @@ describe 'kibana4' do
         :service_ensure   => true,
         :service_enable   => true,
         :manage_user      => true,
-        :kibana4_user     => 'kibana4',
+        :kibana4_user     => 'kib4',
         :kibana4_uid      => '200',
-        :kibana4_group    => 'kibana4',
+        :kibana4_group    => 'kib4',
         :kibana4_gid      => '200',
       }
     end
@@ -239,7 +239,7 @@ describe 'kibana4' do
     it { should contain_file('/opt/kibana4').with_ensure('link').with_target('/opt/kibana-4.0.0-linux-x64') }
     it { should contain_service('kibana4').with_ensure('true').with_enable('true') }
     it { should contain_file('/etc/init.d/kibana4').with_content(/^program=\/opt\/kibana4\/bin\/kibana/) }
-    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kibana4:kibana4 \/ sh -c "/) }
+    it { should contain_file('/etc/init.d/kibana4').with_content(/^  chroot --userspec kib4:kib4 \/ sh -c "/) }
   end
 
 end

--- a/templates/kibana.init
+++ b/templates/kibana.init
@@ -34,11 +34,7 @@ start() {
 
 
   # Run the program!
-<% if scope.lookupvar('kibana4::manage_user')  %>
   chroot --userspec <%= scope.lookupvar('kibana4::kibana4_user') %>:<%= scope.lookupvar('kibana4::kibana4_group') %> / sh -c "
-<% else %>
-  chroot --userspec root:root / sh -c "
-<% end %>
     cd /
 
     exec \"$program\" $args


### PR DESCRIPTION
This sets the kibana4 user and group to "kibana4" by default,
independently of managing the user and group with this module.

The rationale is two-fold: 1) many Puppet sites manage system and user
accounts by means of custom user account modules, via LDAP/AD, or any
other means. Thus running the service as a user other than root should
be possible regardless of whether this module manages the user and
group.

2) It is better to not run the service as root:root in the first place
so let the module assume that a "kibana4" account already exists and use
it OR the administrator has specified a valid user/group via the
`kibana4::user` and `kibana4::group` parameters OR lets the module
manage the user and group account.
