### PR TITLE
pid_file improvement: init and file rights

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,4 +15,11 @@ class kibana4::config {
     notify  => Service['kibana4'],
   }
 
+  file {$kibana4::pid_file:
+    ensure => file,
+    owner  => $kibana4::kibana4_user,
+    group  => $kibana4::kibana4_group,
+    mode   => '0644',
+  }
+
 }

--- a/templates/kibana.init
+++ b/templates/kibana.init
@@ -25,7 +25,7 @@ program=<%= scope.lookupvar('kibana4::symlink_name') %>/bin/kibana
 program=<%= scope.lookupvar('kibana4::install_dir') %>/kibana-<%= scope.lookupvar('kibana4::package_ensure') %>/bin/kibana
 <% end %>
 args=''
-pidfile="/var/run/$name.pid"
+pidfile=<%= scope.lookupvar('kibana4::pid_file') %>/
 
 [ -r /etc/default/$name ] && . /etc/default/$name
 [ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name


### PR DESCRIPTION
the pid file declared in the init doesn't match the pid file declared in the module.
Otherwise, the rights are not set.

So I propose to update the init template and to insert a declaration in the config.pp.
