### PR TITLE
Support optionally using nanliu/archive for archive downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ include kibana4
 If you decided to have the module create a user, you will need to specify
 user name, group name, uid and gid.
 
-Example to install from archive.
-```
+### Example to install from archive
+
+```puppet
   class { '::kibana4':
     package_ensure    => '4.1.1-linux-x64',
     package_provider  => 'archive',
@@ -59,11 +60,36 @@ Example to install from archive.
     elasticsearch_url => 'http://localhost:9200',
   }
 ```
-Example to install from apt or yum repo.
+
+If you prefer to use "nanliu/archive" or "puppet/archive" as the archive
+downloader instead of the default "camptocamp/archive" then set the class
+parameter `archive_provider`. Make sure to have either "nanliu/archive" or
+"puppet/archive" installed since dependency on one of multiple different
+modules with the same name cannot be recorded in metadata.json (by default this
+module uses and depends on "camptocamp/archive").
+
+```puppet
+  class { '::kibana4':
+    package_ensure    => '4.1.1-linux-x64',
+    package_provider  => 'archive',
+    archive_provider  => 'nanliu', # or 'puppet'
+    symlink           => false,
+    manage_user       => true,
+    kibana4_user      => kibana4,
+    kibana4_group     => kibana4,
+    kibana4_gid       => 200,
+    kibana4_uid       => 200,
+    elasticsearch_url => 'http://localhost:9200',
+  }
+```
+
+### Example to install from apt or yum repo
+
 You will need to explicitly set the service_name to 'kibana' in most cases, because
 for legacy reasons the default service_name is set to kibana4 - this may change in the future.
 We disable user and init.d management as these are provided in official packages.
-```
+
+```puppet
 class { '::kibana4':
   package_provider   => 'package',
   package_name       => 'kibana',
@@ -96,6 +122,16 @@ The name of the Kibana4 package that gets installed. Defaults to 'kibana'.
 Set to 'archive' to download Kibana from the Elasticsearch download site (see
 also `package_download_url` below).  Set to 'package' to use the default package
 manager for installation.  Defaults to 'archive'.
+
+[*archive_provider*]
+
+Select which `archive` type should be used to download Kibana from the
+Elasticsearch download site. There exist at least two modules that provide an
+`archive` type: "camptocamp/archive" and "nanliu/archive" (or "puppet/archive"
+since the module is now in the care of puppet-community). Defaults to
+'camptocamp'. If you set this to 'nanliu' (or 'puppet') make sure you have that
+module installed since both cannot be recorded as a dependency in metadata.json
+at the same time.
 
 [*package_download_url*]
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,15 @@
 # also `package_download_url` below).  Set to 'package' to use the default package
 # manager for installation.  Defaults to 'archive'.
 #
+# [*archive_provider*]
+# Select which `archive` type should be used to download Kibana from the
+# Elasticsearch download site. There exist at least two modules that provide an
+# `archive` type: "camptocamp/archive" and "nanliu/archive" (or "puppet/archive"
+# since the module is now in the care of puppet-community). Defaults to
+# 'camptocamp'. If you set this to 'nanliu' (or 'puppet') make sure you have that
+# module installed since both cannot be recorded as a dependency in metadata.json
+# at the same time.
+#
 # [*package_download_url*]
 # Alternative URL from which to download Kibana iff `package_provider` is
 # 'archive'. Defaults to `undef`, because by default the URL is constructed
@@ -24,7 +33,8 @@
 #
 # [*package_proxy_server*]
 # Specifies which proxy server use to download archive. Valid format is
-# http[s]//[user:passwd@]proxy_host:port
+# http[s]//[user:passwd@]proxy_host:port. Not supported when `archive_provider`
+# is 'nanliu' or 'puppet'.
 #
 # [*use_official_repo*]
 # Use official apt or yum repository. Only used if package_provider is set to 'package'.
@@ -94,6 +104,7 @@ class kibana4 (
   $package_ensure              = $kibana4::params::package_ensure,
   $package_name                = $kibana4::params::package_name,
   $package_provider            = $kibana4::params::package_provider,
+  $archive_provider            = $kibana4::params::archive_provider,
   $package_download_url        = $kibana4::params::package_download_url,
   $package_proxy_server        = $kibana4::params::package_proxy_server,
   $use_official_repo           = $kibana4::params::use_official_repo,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,18 +13,49 @@ class kibana4::install {
       default => $kibana4::package_download_url,
     }
 
-    archive { "kibana-${version}":
-      ensure       => present,
-      checksum     => false,
-      target       => $kibana4::install_dir,
-      url          => $download_url,
-      proxy_server => $kibana4::package_proxy_server,
+    case $kibana4::archive_provider {
+      'nanliu','puppet': {
+
+        if $kibana4::package_proxy_server {
+          fail("Setting a proxy server for archive download is not supported when \$archive_provider is '${kibana4::archive_provider}'")
+        }
+
+        archive { "${kibana4::install_dir}/kibana-${version}.tar.gz":
+          ensure        => present,
+          user          => 'root',
+          group         => 'root',
+          source        => $download_url,
+          extract_path  => $kibana4::install_dir,
+          # Extract files as the user doing the extracting, which is the user
+          # that runs Puppet, usually root
+          extract_flags => '-x --no-same-owner -f',
+          creates       => "${kibana4::install_dir}/kibana-${version}",
+          extract       => true,
+          cleanup       => true,
+        }
+
+        $symlink_require = Archive["${kibana4::install_dir}/kibana-${version}.tar.gz"]
+      }
+      'camptocamp': {
+        archive { "kibana-${version}":
+          ensure       => present,
+          checksum     => false,
+          target       => $kibana4::install_dir,
+          url          => $download_url,
+          proxy_server => $kibana4::package_proxy_server,
+        }
+
+        $symlink_require = Archive["kibana-${version}"]
+      }
+      default: {
+        fail("Unsupported \$archive_provider '${kibana4::archive_provider}'. Should be 'camptocamp' or 'nanliu' (aka 'puppet').")
+      }
     }
 
     if $kibana4::symlink {
       file { $kibana4::symlink_name:
         ensure  => link,
-        require => Archive["kibana-${version}"],
+        require => $symlink_require,
         target  => "${kibana4::install_dir}/kibana-${version}",
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class kibana4::params {
   $package_ensure              = '4.1.2-linux-x64'
   $package_name                = 'kibana'
   $package_provider            = 'archive'
+  $archive_provider            = 'camptocamp'
   $package_download_url        = undef
   $package_proxy_server        = undef
   $use_official_repo           = false


### PR DESCRIPTION
nanliu/archive (recently moved to puppet-community and then called
puppet/archive) is an alternative type to download and extract arbitrary
archives from remote locations. This module uses camptocamp/archive by
default but since the module names clash only one can be installed at
the same time. This is unfortunate for users who prefer or have to use
nanliu/archive.

This change adds the ability for the user to choose which "archive
provider" to use by setting the class parameter
`$kibana4::archive_provider` to one of "camptocamp" (the default),
"nanliu" or "puppet". The user must make sure to have either
nanliu/archive or puppet/archive installed since alternative
dependencies cannot be recorded in metadata.json.
