### PR TITLE
Fix issue #26.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,8 +17,8 @@ class kibana4::config {
   file { 'kibana-config-file':
     ensure  => file,
     path    => $_config_file,
-    owner   => root,
-    group   => root,
+    owner   => $kibana4::kibana4_user,
+    group   => $kibana4::kibana4_group,
     mode    => '0755',
     content => template('kibana4/kibana.yml.erb'),
     notify  => Service['kibana4'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -32,6 +32,7 @@ class kibana4::install {
           creates       => "${kibana4::install_dir}/kibana-${version}",
           extract       => true,
           cleanup       => true,
+          notify        => Exec['chown_kibana_directory'],
         }
 
         $symlink_require = Archive["${kibana4::install_dir}/kibana-${version}.tar.gz"]
@@ -43,6 +44,7 @@ class kibana4::install {
           target       => $kibana4::install_dir,
           url          => $download_url,
           proxy_server => $kibana4::package_proxy_server,
+          notify       => Exec['chown_kibana_directory'],
         }
 
         $symlink_require = Archive["kibana-${version}"]
@@ -52,11 +54,20 @@ class kibana4::install {
       }
     }
 
+    exec { 'chown_kibana_directory':
+      command     => "chown -R ${kibana4::kibana4_user}:${kibana4::kibana4_group} ${kibana4::install_dir}/kibana-${version}",
+      path        => ['/bin','/sbin'],
+      refreshonly => true,
+      require     => $symlink_require,
+    }
+
     if $kibana4::symlink {
       file { $kibana4::symlink_name:
         ensure  => link,
         require => $symlink_require,
         target  => "${kibana4::install_dir}/kibana-${version}",
+        owner   => $kibana4::kibana4_user,
+        group   => $kibana4::kibana4_group,
       }
     }
   }


### PR DESCRIPTION
Change ownership of extarcted kibana directory & symlink (if enabled) to
kibana_user & kibana_group.
Config fie ownership changed to kibana_usr & kibana_group to prevent
ownvership reverting to 'root' on each puppet run.
