### PR TITLE
manage babel_cache_path in /etc/default/kibana4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,6 +93,9 @@
 # [*kibana4_gid*]
 # The group ID assigned to the group specified in `kibana4_group`. Defaults to `undef`.
 #
+# [*babel_cache_path*]
+# Kibana uses babel (https://www.npmjs.com/package/babel) which writes it's cache to this location
+#
 # === Examples
 #
 #  class { '::kibana4':
@@ -139,6 +142,7 @@ class kibana4 (
   $ssl_cert_file               = $kibana4::params::ssl_cert_file,
   $pid_file                    = $kibana4::params::pid_file,
   $bundled_plugin_ids          = $kibana4::params::bundled_plugin_ids,
+  $babel_cache_path            = $kibana4::params::babel_cache_path,
 ) inherits kibana4::params {
 
   class {'kibana4::user': }->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,5 +46,6 @@ class kibana4::params {
     'plugins/markdown_vis/index','plugins/metric_vis/index',
     'plugins/settings/index','plugins/table_vis/index',
     'plugins/vis_types/index','plugins/visualize/index' ]
+  $babel_cache_path            = '/tmp/babel.cache'
 }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,7 +13,16 @@ class kibana4::service {
       group   => root,
       owner   => root,
     }
-    $require = File["/etc/init.d/${kibana4::service_name}"]
+
+    file { '/etc/default/kibana4':
+      ensure  => file,
+      mode    => '0755',
+      content => template('kibana4/default.erb'),
+      group   => root,
+      owner   => root,
+    }
+
+    $require = [File["/etc/init.d/${kibana4::service_name}"], File['/etc/default/kibana4']]
   } else {
     $require = undef
   }

--- a/templates/default.erb
+++ b/templates/default.erb
@@ -1,0 +1,1 @@
+export BABEL_CACHE_PATH=<%= scope.lookupvar('kibana4::babel_cache_path') %>


### PR DESCRIPTION
if we install kibana 4.2.1 from archive with this module it tries to
write a single cache file to it's project directory when kibana
starts. This commit adds management of /etc/default/kibana4 which
will be loaded by the init.d script and sets the BABEL_CACHE_PATH to
/tmp (by default, this can be adjusted by overriding a class
parameter in init.pp)
