### PR TITLE
Sort config keys for ruby 1.8

### DIFF
--- a/templates/kibana.yml.erb
+++ b/templates/kibana.yml.erb
@@ -1,5 +1,5 @@
 # This file is managed by Puppet, any changes will be overwritten
 
-<% scope['kibana4::config'].each_key do |key| -%>
+<% scope['kibana4::config'].keys.sort.each do |key| -%>
 <%= key %>: <%= scope['kibana4::config'][key] %>
 <% end -%>


### PR DESCRIPTION
In ruby 1.8 (default for RHEL6/CentOS6) the each_key method doesn't sort the keys consistently which results in a change in the config file on every puppet run. A sort on the keys fixes this.
