### PR TITLE
Sets service_provider based on OS

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class kibana4::params {
   $service_ensure                = true
   $service_enable                = true
   $service_name                  = 'kibana'
-  case $operatingsystem {
+  case ${::operatingsystem} {
     /^(Debian|Ubuntu)$/ : { $service_provider = debian }
     default:              { $service_provider = init   }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,10 @@ class kibana4::params {
   $service_ensure                = true
   $service_enable                = true
   $service_name                  = 'kibana'
+  case $operatingsystem {
+    /^(Debian|Ubuntu)$/ : { $service_provider = debian }
+    default:              { $service_provider = init   }
+  }
   $manage_init_file              = true
   $init_template                 = 'kibana4/kibana.init.erb'
   $manage_user                   = false

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -32,7 +32,7 @@ class kibana4::service {
     ensure     => $kibana4::service_ensure,
     enable     => $kibana4::service_enable,
     name       => $kibana4::service_name,
-    provider   => init,
+    provider   => $kibana4::service_provider,
     hasstatus  => true,
     hasrestart => true,
     require    => $require,


### PR DESCRIPTION
I found that this puppet module would not work on my Ubuntu 14.04.3 installation due to the service provider differences on CentOS and Ubuntu. I successfully tested my change on both CentOS 7 and Ubuntu 14.04.3.
