### PR TITLE
Puppet service provider set based on operating system

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class kibana4::params {
   $service_ensure                = true
   $service_enable                = true
   $service_name                  = 'kibana'
-  case $operatingsystem {
+  case ${::operatingsystem} {
     /^(Debian|Ubuntu)$/ : { $service_provider = debian }
     default:              { $service_provider = init   }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,10 @@ class kibana4::params {
   $service_ensure                = true
   $service_enable                = true
   $service_name                  = 'kibana'
+  case $operatingsystem {
+    /^(Debian|Ubuntu)$/ : { $service_provider = debian }
+    default:              { $service_provider = init   }
+  }
   $manage_init_file              = true
   $init_template                 = 'kibana4/kibana.init.erb'
   $manage_user                   = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class kibana4::params {
   $service_ensure                = true
   $service_enable                = true
   $service_name                  = 'kibana'
-  case ${::operatingsystem} {
+  case $::operatingsystem {
     /^(Debian|Ubuntu)$/ : { $service_provider = debian }
     default:              { $service_provider = init   }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -32,7 +32,7 @@ class kibana4::service {
     ensure     => $kibana4::service_ensure,
     enable     => $kibana4::service_enable,
     name       => $kibana4::service_name,
-    provider   => init,
+    provider   => $kibana4::service_provider,
     hasstatus  => true,
     hasrestart => true,
     require    => $require,


### PR DESCRIPTION
Module didn't work in Ubuntu 14.04.3 and puppet 4.3.2. Added in a check to set the service provider depending on whether it is Ubuntu/Debian or not.
