### PR TITLE
add proxy support for package installations

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
-     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-     archive: "git://github.com/camptocamp/puppet-archive.git"
-     apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
+     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+     archive: "https://github.com/camptocamp/puppet-archive.git"
+     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
   symlinks:
     'kibana4': "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Use official apt or yum repository. Only used if install_method is set to 'packa
 
 Apt or yum repository version. Only used if 'package_use_official_repo' is set to 'true'.  Defaults to '4.1'.
 
+#### `package_repo_proxy`
+
+Whether or not to use a proxy for downloading the kibana4 package. Default is 'undef, so no proxy will be used.
+
 #### `service_ensure`
 
 Specifies the service state. Valid values are stopped (false) and running (true).  Defaults to 'running'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,10 @@
 # Installation directory used if install_method is 'package'
 # Defaults to '/opt/kibana'. You can change this if you are using custom packages.
 #
+# [*package_repo_proxy*]
+# A proxy to use for downloading packages.
+# Defaults to 'undef'. You can change this if you are behind a proxy
+#
 # [*config_file*]
 # The location, as a path, of the Kibana configuration file.
 #
@@ -119,6 +123,7 @@ class kibana4 (
   $package_use_official_repo     = $kibana4::params::package_use_official_repo,
   $package_repo_version          = $kibana4::params::package_repo_version,
   $package_install_dir           = $kibana4::params::package_install_dir,
+  $package_repo_proxy            = undef,
   $service_ensure                = $kibana4::params::service_ensure,
   $service_enable                = $kibana4::params::service_enable,
   $service_name                  = $kibana4::params::service_name,

--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -10,12 +10,13 @@ class kibana4::install::package {
 
       'RedHat': {
         yumrepo { "kibana-${kibana4::package_repo_version}":
-        baseurl  => "http://packages.elastic.co/kibana/${kibana4::package_repo_version}/centos",
-        enabled  => '1',
-        gpgcheck => '1',
-        gpgkey   => 'https://packages.elastic.co/GPG-KEY-elasticsearch',
-        descr    => "Kibana repository for ${kibana4::package_repo_version}.x packages",
-        before   => Package['kibana4'],
+          baseurl  => "http://packages.elastic.co/kibana/${kibana4::package_repo_version}/centos",
+          enabled  => '1',
+          gpgcheck => '1',
+          gpgkey   => 'https://packages.elastic.co/GPG-KEY-elasticsearch',
+          descr    => "Kibana repository for ${kibana4::package_repo_version}.x packages",
+          proxy    => $kibana4::package_repo_proxy,
+          before   => Package['kibana4'],
         }
       }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -395,6 +395,28 @@ describe 'kibana4' do
       it { is_expected.to contain_yumrepo('kibana-4.1') }
     end
 
+    context 'using the official repos on CentOS behind a proxy' do
+      let :facts do
+        {
+          :osfamily => 'RedHat'
+        }
+      end
+      let :params do
+        {
+          :install_method            => 'package',
+          :package_name              => 'kibana',
+          :service_name              => 'kibana',
+          :package_use_official_repo => true,
+          :package_repo_version      => '4.1',
+          :package_repo_proxy        => 'http://proxy:8080'
+
+        }
+      end
+      it { should contain_package('kibana4').with_name('kibana')}
+      it { should contain_service('kibana4').with_ensure('true').with_name('kibana') }
+      it { should contain_yumrepo('kibana-4.1').with_proxy('http://proxy:8080') }
+    end
+
     context 'using the official repos on Ubuntu' do
       let :facts do
         {


### PR DESCRIPTION
- use https uri's in .fixtures
- support proxy when using packages
- minimal fixes to make puppet-lint happier
