### PR TITLE
Add feature manage_repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Version of Kibana4 that gets installed.  Defaults to the latest version availabl
 
 This parameter is deprecated. Only package installation from official `elastic.co` repositories is supported.
 
+#### `manage_repo`
+
+Whether or not to have the module also manage the Yum or Apt repos.  Defaults to 'true'.
+
 #### `package_repo_version`
 
 Apt or yum repository version. Defaults to '4.5'.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,20 +4,17 @@
 #
 class kibana4::config {
 
-    $_config_file = '/opt/kibana/config/kibana.yml'
-
   if $kibana4::config {
 
     file { 'kibana-config-file':
       ensure  => file,
-      path    => $_config_file,
-      owner   => $kibana4::kibana4_user,
-      group   => $kibana4::kibana4_group,
+      path    => '/opt/kibana/config/kibana.yml',
+      owner   => 'kibana',
+      group   => 'kibana',
       mode    => '0755',
       content => template('kibana4/kibana.yml.erb'),
       notify  => Service['kibana4'],
     }
-
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,9 +8,16 @@
 # Version of Kibana4 that gets installed.  Defaults to the latest version
 # available in the `package_repo_version` that is selected.
 #
+# [*manage_repo*]
+# Enable repo management by enabling the official repositories.
+#
 # [*package_repo_version*]
 # apt or yum repository version. Only used if 'package_use_official_repo' is set to 'true'.
 # defaults to '4.5'.
+#
+# [*package_repo_proxy*]
+# A proxy to use for downloading packages.
+# Defaults to 'undef'. You can change this if you are behind a proxy
 #
 # [*service_ensure*]
 # Specifies the service state. Valid values are stopped (false) and running
@@ -23,10 +30,6 @@
 # [*service_name*]
 # Name of the Kibana4 service. Defaults to 'kibana'.
 #
-# [*package_repo_proxy*]
-# A proxy to use for downloading packages.
-# Defaults to 'undef'. You can change this if you are behind a proxy
-#
 # [*babel_cache_path*]
 # Kibana uses babel (https://www.npmjs.com/package/babel) which writes it's cache to this location
 #
@@ -36,6 +39,7 @@
 #
 class kibana4 (
   $version                       = $kibana4::params::version,
+  $manage_repo                   = $kibana4::params::manage_repo,
   $package_repo_version          = $kibana4::params::package_repo_version,
   $package_repo_proxy            = undef,
   $service_ensure                = $kibana4::params::service_ensure,
@@ -44,6 +48,12 @@ class kibana4 (
   $config                        = $kibana4::params::config,
   $plugins                       = undef,
 ) inherits kibana4::params {
+
+  validate_bool($manage_repo)
+
+  if ($manage_repo) {
+    validate_string($package_repo_version)
+  }
 
   class {'kibana4::install': }->
   class {'kibana4::config': }->
@@ -55,5 +65,4 @@ class kibana4 (
     validate_hash($plugins)
     create_resources('kibana4::plugin', $plugins)
   }
-
 }

--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -4,6 +4,8 @@
 #
 class kibana4::install::package {
 
+  if ($kibana4::manage_repo) {
+
     case $::osfamily {
 
       'RedHat': {
@@ -40,13 +42,11 @@ class kibana4::install::package {
       default: {
         fail("${::operatingsystem} not supported")
       }
-
     }
-
+  }
 
   package { 'kibana4':
     ensure => $kibana4::version,
     name   => kibana,
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@
 class kibana4::params {
   $babel_cache_path              = '/tmp/babel.cache'
   $version                       = 'latest'
+  $manage_repo                   = true
   $package_repo_version          = '4.5'
   $package_install_dir           = '/opt/kibana'
   $service_ensure                = true

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -34,4 +34,32 @@ describe 'kibana4' do
     it { is_expected.to contain_service('kibana4').with_ensure('true').with_enable('true') }
   end
 
+  context 'with manage_repo unspecified' do
+    let :facts do
+      {
+         :osfamily => 'RedHat'
+      }
+    end
+    let :params do
+      {
+        :package_repo_version => '4.5',
+      }
+    end
+    it { is_expected.to contain_yumrepo('kibana-4.5') }
+  end
+
+  context 'with manage_repo set to false' do
+    let :facts do
+      {
+         :osfamily => 'RedHat'
+      }
+    end
+    let :params do
+      {
+        :manage_repo          => false,
+        :package_repo_version => '4.5',
+      }
+    end
+    it { is_expected.to_not contain_yumrepo('kibana-4.5') }
+  end
 end


### PR DESCRIPTION
This adds the same feature that the Elastic.co modules have, allowing us to optionally not manage the Yum/Apt repos.
