### PR TITLE
Handle arrays in config hash

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -62,4 +62,30 @@ describe 'kibana4' do
     end
     it { is_expected.to_not contain_yumrepo('kibana-4.5') }
   end
+
+  context 'handles array values in the config hash' do
+    let :facts do
+      {
+         :osfamily => 'RedHat'
+      }
+    end
+    let :params do
+      {
+        :version             => 'latest',
+        :service_ensure      => true,
+        :service_enable      => true,
+        :config		     => {
+          'server.port'           => 5601,
+          'server.host'           => '0.0.0.0',
+          'elasticsearch.url'     => 'http://localhost:9200',
+          'bundled_plugin_ids'    => [
+            'plugins/visualize/index'
+          ]
+        }
+      }
+    end
+    it { is_expected.to contain_file('kibana-config-file')
+      .with_content(/^(  - plugins\/visualize\/index)$/) }
+  end
+
 end

--- a/templates/kibana.yml.erb
+++ b/templates/kibana.yml.erb
@@ -1,5 +1,12 @@
 # This file is managed by Puppet, any changes will be overwritten
 
 <% scope['kibana4::config'].keys.sort.each do |key| -%>
+<% unless scope['kibana4::config'][key].is_a?(Array) -%>
 <%= key %>: <%= scope['kibana4::config'][key] %>
+<% else -%>
+<%= key %>:
+<% scope['kibana4::config'][key].each do |e| -%>
+  - <%= e %>
+<% end -%>
+<% end -%>
 <% end -%>

--- a/templates/kibana.yml.erb
+++ b/templates/kibana.yml.erb
@@ -1,12 +1,12 @@
 # This file is managed by Puppet, any changes will be overwritten
 
 <% scope['kibana4::config'].keys.sort.each do |key| -%>
-<% unless scope['kibana4::config'][key].is_a?(Array) -%>
-<%= key %>: <%= scope['kibana4::config'][key] %>
-<% else -%>
+<% if scope['kibana4::config'][key].is_a?(Array) -%>
 <%= key %>:
 <% scope['kibana4::config'][key].each do |e| -%>
   - <%= e %>
 <% end -%>
+<% else -%>
+<%= key %>: <%= scope['kibana4::config'][key] %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This addresses #64 - and allows us to ensure that the older config for Kibana 4.1 can still be used with this module.
