### PR TITLE
Outgoing proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ class { 'kibana4':
        plugin_dest_dir    => 'marvel',                       # mandatory - plugin will be installed in ${kibana4_plugin_dir}/${plugin_dest_dir}
        url                => 'http://your_custom_url',       # necessary if using arbitrary URL
        ensure             => present,                        # mandatory - either 'present' or 'absent'
+       http_proxy         => 'http://proxy.domain.com:8080', # optional - used only if 'url' parameter is specified (otherwise ignored)
     },
     'elastic/sense' => {
        ensure          => present,

--- a/files/kibana_plugin_install_proxy.sh
+++ b/files/kibana_plugin_install_proxy.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# By Fat Dragon, 09/06/2016
+# Downloads Kibana plugin through outgoing http proxy and installs it
+# (Workaround for https://github.com/elastic/kibana/issues/5902) 
+# Arguments:
+# kibana_plugin_install_proxy.sh <plugin_name> <url> <kibana4_plugin_dir> <http_proxy>
+
+# Gathers input
+if [ $# -ne 4 ]
+then
+    echo "kibana_plugin_install_proxy.sh <plugin_name> <url> <kibana4_plugin_dir> <http_proxy>"
+    exit 1
+fi
+
+plugin_name=$1
+url=$2
+kibana4_plugin_dir=$3
+http_proxy=$4
+
+file_name="/tmp/$(basename $url)"
+
+# Ensures that the file does not exist
+if [ -f $file_name ]; then
+	rm $file_name
+fi
+
+# Downloads the file
+wget -e use_proxy=yes -e http_proxy=$http_proxy $url -O $file_name
+status=$?
+
+if [ $status -ne 0 ]; then
+
+	# Ensures that the file does not exist
+	if [ -f $file_name ]; then
+		rm $file_name
+	fi
+
+	echo "Download failed."
+	exit $status
+
+fi
+
+# Rechecks for file
+if [ ! -f $file_name ]; then
+
+	echo "Strange, but the file is missing."
+	exit 1
+
+fi
+
+# Installing
+/opt/kibana/bin/kibana plugin --install $plugin_name -u "file://${file_name}" -d $kibana4_plugin_dir
+status=$?
+
+# Cleanup
+rm $file_name
+
+
+if [ $status -eq 0 ]; then
+	echo "Finished."
+else
+	echo "Install failed."
+fi
+
+exit $status

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,12 +6,12 @@ class kibana4::install {
 
   contain kibana4::install::package
 
-	file { 'kibana_plugin_install_proxy.sh': 
-	  ensure  => 'file', 
-	  path    => '/opt/kibana/kibana_plugin_install_proxy.sh', 
-	  mode    => '0755', 
-	  source  => 'puppet:///modules/kibana4/kibana_plugin_install_proxy.sh', 
+  file { 'kibana_plugin_install_proxy.sh': 
+    ensure  => 'file', 
+    path    => '/opt/kibana/kibana_plugin_install_proxy.sh', 
+    mode    => '0755', 
+    source  => 'puppet:///modules/kibana4/kibana_plugin_install_proxy.sh', 
     require => Class['kibana4::install::package'], 
-	}
+  }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,4 +6,12 @@ class kibana4::install {
 
   contain kibana4::install::package
 
+	file { 'kibana_plugin_install_proxy.sh': 
+	  ensure  => 'file', 
+	  path    => '/opt/kibana/kibana_plugin_install_proxy.sh', 
+	  mode    => '0755', 
+	  source  => 'puppet:///modules/kibana4/kibana_plugin_install_proxy.sh', 
+    require => Class['kibana4::install::package'], 
+	}
+
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -25,12 +25,19 @@
 #   Specify an URL where to download the plugin from.
 #   This variable is optional
 #
+# [*http_proxy*]
+#   Outgoing HTTP proxy. It is used ONLY if *url* parameter
+#   is specified; otherwise it will be ignored.
+#   Example: 'http://proxy.domain.com:8080'
+#   This variable is optional
+#
 
 define kibana4::plugin(
   $plugin_dest_dir        = undef,
   $kibana4_plugin_dir     = '/opt/kibana/installedPlugins',
   $ensure                 = 'present',
   $url                    = undef,
+  $http_proxy             = undef, 
 ) {
 
   if !$plugin_dest_dir {
@@ -42,23 +49,19 @@ define kibana4::plugin(
     'present': {
 
       if !$url {
-
-        exec { "install_kibana_plugin_${name}":
-        command => "/opt/kibana/bin/kibana plugin --install ${name} -d ${kibana4_plugin_dir}",
-        path    => '/opt/kibana:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-        unless  => "test -d ${kibana4_plugin_dir}/${plugin_dest_dir}",
-        notify  => Service['kibana'],
-        }
-
+        $install_command = "/opt/kibana/bin/kibana plugin --install ${name} -d ${kibana4_plugin_dir}"
+      } elsif $http_proxy != undef and $http_proxy != '' {
+        # Note that $plugin_dest_dir is used instad of $name (short name is needed)
+        $install_command = "/opt/kibana/kibana_plugin_install_proxy.sh ${plugin_dest_dir} ${url} ${kibana4_plugin_dir} ${http_proxy}"
       } else {
+        $install_command = "/opt/kibana/bin/kibana plugin --install ${name} -u ${url} -d ${kibana4_plugin_dir}"
+      }
 
-        exec { "install_kibana_plugin_${name}":
-        command => "/opt/kibana/bin/kibana plugin --install ${name} -u ${url} -d ${kibana4_plugin_dir}",
+      exec { "install_kibana_plugin_${name}":
+        command => $install_command,
         path    => '/opt/kibana:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
         unless  => "test -d ${kibana4_plugin_dir}/${plugin_dest_dir}",
         notify  => Service['kibana'],
-        }
-
       }
 
     }


### PR DESCRIPTION
`http_proxy` parameter introduced into `kibana4::plugin` type. It's actually workaround for https://github.com/elastic/kibana/issues/5902

To explain changes:
- `kibana_plugin_install_proxy.sh` file added (downloads the plugin through proxy to `/tmp` directory, and then executes `/opt/kibana/bin/kibana --install` to install it.
- `file` resource that installs `kibana_plugin_install_proxy.sh` script is added to `install.pp`
- One `elsif` option is added to `plugin.pp` that checks if `http_proxy` is specified, and if it is calls the new script file instead of executing `/opt/kibana/bin/kibana --install` directly. Other two options **are unchanged** (only cosmetic change that avoids repetition). 

It works - I'm already using it in my environment.
