### PR TITLE
Removed deprecated usage of user and group #62

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,8 +11,6 @@ class kibana4::config {
     file { 'kibana-config-file':
       ensure  => file,
       path    => $_config_file,
-      owner   => $kibana4::kibana4_user,
-      group   => $kibana4::kibana4_group,
       mode    => '0755',
       content => template('kibana4/kibana.yml.erb'),
       notify  => Service['kibana4'],


### PR DESCRIPTION
Fixes #62, where reference to username and group were still present. As a configuration file it should not be owned by the user running the application also.
