### PR TITLE
update kibana4 class with service provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class kibana4 (
   $service_ensure                = $kibana4::params::service_ensure,
   $service_enable                = $kibana4::params::service_enable,
   $service_name                  = $kibana4::params::service_name,
+  $service_provider              = $kibana4::params::service_provider,
   $config                        = $kibana4::params::config,
   $plugins                       = undef,
 ) inherits kibana4::params {


### PR DESCRIPTION
Missing kibana4::service_provider params from what is required on kibana4::service. This fixes the problem Error: /Stage[main]/Kibana4::Service/Service[kibana4]: Provider init is not functional on this host
