### PR TITLE
change service provider for redhat variants

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,8 +15,8 @@ class kibana4::params {
     'Debian': { $service_provider = debian }
     'RedHat': {
       case $::operatingsystemmajrelease {
-        '7': { $service_provider = systemd }
-        default: { $service_provider = init }
+        '7': { $service_provider = 'systemd' }
+        default: { $service_provider = 'redhat' }
       }
     }
     default: { $service_provider = init   }


### PR DESCRIPTION
redhat variants rely on the 'redhat' provider not init. Using the init provider will trigger
Error: /Stage[main]/Kibana4::Service/Service[kibana4]: Provider init is not functional on this host
