### PR TITLE
Setting provider to undef for RedHat less than 7.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class kibana4::params {
     'RedHat': {
       case $::operatingsystemmajrelease {
         '7': { $service_provider = systemd }
-        default: { $service_provider = init }
+        default: { $service_provider = undef }
       }
     }
     default: { $service_provider = init   }


### PR DESCRIPTION
Currently this is causing the following error:
'Provider init is not functional on this host'
