### PR TITLE
Service defaults for RedHat OSFamily

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class kibana4::params {
     'RedHat': {
       case $::operatingsystemmajrelease {
         '7': { $service_provider = systemd }
-        default: { $service_provider = init }
+        default: { $service_provider = redhat }
       }
     }
     default: { $service_provider = init   }


### PR DESCRIPTION
The service provider for RedHat osfamily is not init, is redhat per documentation: https://docs.puppet.com/puppet/latest/reference/types/service.html#service-provider-redhat

Also, why is this module trying to set the provider for the service?

Not working on CentOS 6 with the error:
Error: /Stage[main]/Kibana4::Service/Service[kibana4]: Provider init is not functional on this host
