### PR TITLE
Allow override of package name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,9 @@
 # A proxy to use for downloading packages.
 # Defaults to 'undef'. You can change this if you are behind a proxy
 #
+# [*package_name*]
+# Name of the kibana package to install. Defaults to 'kibana'.
+#
 # [*service_ensure*]
 # Specifies the service state. Valid values are stopped (false) and running
 # (true). Defaults to 'running'.
@@ -42,6 +45,7 @@ class kibana4 (
   $manage_repo                   = $kibana4::params::manage_repo,
   $package_repo_version          = $kibana4::params::package_repo_version,
   $package_repo_proxy            = undef,
+  $package_name                  = $kibana4::params::package_name,
   $service_ensure                = $kibana4::params::service_ensure,
   $service_enable                = $kibana4::params::service_enable,
   $service_name                  = $kibana4::params::service_name,

--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -47,6 +47,6 @@ class kibana4::install::package {
 
   package { 'kibana4':
     ensure => $kibana4::version,
-    name   => kibana,
+    name   => $kibana4::package_name,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class kibana4::params {
   $manage_repo                   = true
   $package_repo_version          = '4.5'
   $package_install_dir           = '/opt/kibana'
+  $package_name                  = 'kibana'
   $service_ensure                = true
   $service_enable                = true
   $service_name                  = 'kibana'


### PR DESCRIPTION
This allows e.g. to use the "official Debian" `kibana-4.4` package
