### PR TITLE
Allow path to config file to be overridden

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,9 +8,9 @@ class kibana4::config {
 
     file { 'kibana-config-file':
       ensure  => file,
-      path    => $kibana4::config_path,
-      owner   => 'kibana',
-      group   => 'kibana',
+      path    => $kibana4::config_file,
+      owner   => $kibana4::config_file_owner,
+      group   => $kibana4::config_file_group,
       mode    => '0755',
       content => template('kibana4/kibana.yml.erb'),
       notify  => Service['kibana4'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,7 @@ class kibana4::config {
       path    => $kibana4::config_file,
       owner   => $kibana4::config_file_owner,
       group   => $kibana4::config_file_group,
-      mode    => '0755',
+      mode    => '0644',
       content => template('kibana4/kibana.yml.erb'),
       notify  => Service['kibana4'],
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,7 @@ class kibana4::config {
 
     file { 'kibana-config-file':
       ensure  => file,
-      path    => '/opt/kibana/config/kibana.yml',
+      path    => $kibana4::config_path,
       owner   => 'kibana',
       group   => 'kibana',
       mode    => '0755',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class kibana4 (
   $service_name                  = $kibana4::params::service_name,
   $service_provider              = $kibana4::params::service_provider,
   $config                        = $kibana4::params::config,
+  $config_path                   = $kibana4::params::config_path,
   $plugins                       = undef,
 ) inherits kibana4::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,9 @@ class kibana4 (
   $service_name                  = $kibana4::params::service_name,
   $service_provider              = $kibana4::params::service_provider,
   $config                        = $kibana4::params::config,
-  $config_path                   = $kibana4::params::config_path,
+  $config_file                   = $kibana4::params::config_file,
+  $config_file_owner             = $kibana4::params::config_file_owner,
+  $config_file_group             = $kibana4::params::config_file_group,
   $plugins                       = undef,
 ) inherits kibana4::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,4 +22,5 @@ class kibana4::params {
     default: { $service_provider = init   }
   }
   $config                        = undef
+  $config_path                   = '/opt/kibana/config/kibana.yml'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,5 +22,7 @@ class kibana4::params {
     default: { $service_provider = init   }
   }
   $config                        = undef
-  $config_path                   = '/opt/kibana/config/kibana.yml'
+  $config_file                   = '/opt/kibana/config/kibana.yml'
+  $config_file_owner             = 'kibana'
+  $config_file_group             = 'kibana'
 }


### PR DESCRIPTION
This allows this modules to be used to manage the Debian default path of
`/etc/kibana-4.4.yaml`.
