### PR TITLE
manage boot with chkconfig on old EL distribs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,6 @@ rvm:
   - 1.9.3
   - 2.0.0
 env:
-  - PUPPET_GEM_VERSION="~> 2.7.0"
-  - PUPPET_GEM_VERSION="~> 3.0.0"
-  - PUPPET_GEM_VERSION="~> 3.1.0"
-  - PUPPET_GEM_VERSION="~> 3.2.0"
-  - PUPPET_GEM_VERSION="~> 3.3.0"
   - PUPPET_GEM_VERSION="~> 3.4.0"
   - PUPPET_GEM_VERSION="~> 3.5.0"
   - PUPPET_GEM_VERSION="~> 3.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development, :unit_tests do
   gem 'simplecov',                 :require => false
   gem 'rspec-puppet-facts',        :require => false
   gem 'retriable', '< 3' if RUBY_VERSION < '2'
-  gem 'nokogiri', '< 1.8' if RUBY_VERSION < '2.1'
+  gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1'
 end
 group :system_tests do
   gem 'beaker-rspec', '< 6',           *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 3.4')

--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,10 @@ group :development, :unit_tests do
   gem 'rspec-puppet', '>= 2.3.2',  :require => false
   gem 'simplecov',                 :require => false
   gem 'rspec-puppet-facts',        :require => false
+  gem 'retriable', '< 3' if RUBY_VERSION < '2'
 end
 group :system_tests do
-  gem 'beaker-rspec',                  *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 3.4')
+  gem 'beaker-rspec', '< 6',           *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 3.4')
   gem 'beaker',                        *location_for(ENV['BEAKER_VERSION'])
   gem 'public_suffix', '~> 1.4.0',     :require => false
   gem 'serverspec',                    :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :unit_tests do
   gem 'simplecov',                 :require => false
   gem 'rspec-puppet-facts',        :require => false
   gem 'retriable', '< 3' if RUBY_VERSION < '2'
+  gem 'nokogiri', '< 1.8' if RUBY_VERSION < '2.1'
 end
 group :system_tests do
   gem 'beaker-rspec', '< 6',           *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 3.4')

--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,11 @@ def location_for(place, version = nil)
   end
 end
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+puppetversion = ENV.key?('PUPPET_GEM_VERSION') ? "#{ENV['PUPPET_GEM_VERSION']}" : ['>= 3.3']
 
 group :development, :unit_tests do
   gem 'json',                      :require => false
-  gem 'metadata-json-lint', '< 1.7' if RUBY_VERSION < '2.1'
+  gem 'metadata-json-lint', '< 1.2' if RUBY_VERSION < '2.1'
   gem 'puppet_facts',              :require => false
   gem 'puppet-blacksmith',         :require => false
   gem 'puppetlabs_spec_helper',    :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>=
 
 group :development, :unit_tests do
   gem 'json',                      :require => false
-  gem 'metadata-json-lint',        :require => false
+  gem 'metadata-json-lint', '< 1.7' if RUBY_VERSION < '2.1'
   gem 'puppet_facts',              :require => false
   gem 'puppet-blacksmith',         :require => false
   gem 'puppetlabs_spec_helper',    :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ end
 group :system_tests do
   gem 'beaker-rspec',                  *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 3.4')
   gem 'beaker',                        *location_for(ENV['BEAKER_VERSION'])
+  gem 'public_suffix', '~> 1.4.0',     :require => false
   gem 'serverspec',                    :require => false
   gem 'beaker-puppet_install_helper',  :require => false
   gem 'master_manipulator',            :require => false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,9 +56,9 @@ class kibana4 (
     validate_string($package_repo_version)
   }
 
-  class {'kibana4::install': }->
-  class {'kibana4::config': }->
-  class {'kibana4::service': }
+  class {'kibana4::install': }
+->class {'kibana4::config': }
+->class {'kibana4::service': }
 
   Kibana4::Plugin { require => Class['kibana4::install'] }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class kibana4::params {
     'RedHat': {
       case $::operatingsystemmajrelease {
         '7': { $service_provider = systemd }
-        default: { $service_provider = init }
+        default: { $service_provider = redhat }
       }
     }
     default: { $service_provider = init   }


### PR DESCRIPTION
chkconfig missing in post-install script of RPM package
but puppet can check and do that